### PR TITLE
removed map header

### DIFF
--- a/src/components/io-extended-25/About.astro
+++ b/src/components/io-extended-25/About.astro
@@ -77,9 +77,6 @@ import { Separator } from "@/components/ui/separator"
                     <Separator orientation="vertical" className="h-full" />
                 </div>
                 <div class="space-y-6 lg:pl-8">
-                    <h3 class="text-2xl font-semibold text-black">
-                        Ubicación del Evento
-                    </h3>
                     <div class="relative">
                         <div
                             class="w-full h-[400px] lg:h-[450px] rounded-2xl overflow-hidden border border-border shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-[1.02]"


### PR DESCRIPTION
This PR removes the "Ubicacion del Evento" header on the about section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilo**
  * Se eliminó el encabezado "Ubicación del Evento" en la vista de escritorio de la sección correspondiente, manteniendo el mapa y su leyenda sin cambios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->