### PR TITLE
style(agenda): arregalar titulos de las secciones speakers y agenda

### DIFF
--- a/src/components/io-extended-25/agenda/ActivityCard.astro
+++ b/src/components/io-extended-25/agenda/ActivityCard.astro
@@ -14,5 +14,5 @@ const { start, end, title }: Props = Astro.props
   <p class="text-[24px] font-bold text-blue-500 text-center">
     <span>{start}</span> - <span>{end}</span>
   </p>
-  <p class="text-[28px] md:text-[36px] text-[#202124] text-center font-bold">{title.toLocaleUpperCase()}</p>
+  <p class="text-2xl md:text-[36px] text-[#202124] text-center font-bold">{title.toLocaleUpperCase()}</p>
 </div>

--- a/src/components/io-extended-25/agenda/Agenda.astro
+++ b/src/components/io-extended-25/agenda/Agenda.astro
@@ -11,7 +11,7 @@ import saraImg from "@/assets/io-extended-25/speakers/Sara-Salazar.webp"
 
 <!-- Seccion de Agenda -->
 <div class="flex flex-col justify-center items-center gap-[52px] my-6 px-4">
-  <h2 class="font-bold text-[48px]">AGENDA</h2>
+  <h2 class="font-bold text-3xl md:text-5xl">AGENDA</h2>
   <!-- Contenido de la Agenda -->
   <div class="flex flex-col xl:flex-row md:flex-col gap-[36px] lg:gap-[44px]">
     <!-- Izquierda -->

--- a/src/components/io-extended-25/speakers/SpeakersSection.astro
+++ b/src/components/io-extended-25/speakers/SpeakersSection.astro
@@ -48,7 +48,7 @@ const speakersList = [
 ---
 
 <section id="speakers" class="flex flex-col items-center gap-4 w-full px-4 pb-16">
-  <h2 class="text-2xl md:text-4xl font-bold text-black leading-tight text-center pb-4 md:pb-10">
+  <h2 class="text-3xl md:text-5xl font-bold text-black leading-tight text-center pb-4 md:pb-10">
     SPEAKERS
   </h2>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilo**
  * Se ajustaron los tamaños de fuente de los títulos en las secciones de agenda y ponentes para mejorar la legibilidad y la consistencia visual en diferentes tamaños de pantalla.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->