### PR TITLE
Check registration before getting a team

### DIFF
--- a/src/components/registration/RegisterForm.tsx
+++ b/src/components/registration/RegisterForm.tsx
@@ -136,7 +136,7 @@ export function RegisterForm({ formFields, profile, event }: RegisterFormProps) 
             )}
           />
         ))}
-        <Button className="w-full bg-blue-500 dark:text-white" type="submit">
+        <Button className="w-full bg-blue-500 dark:text-white" type="submit" disabled={loading}>
           {loading && <Loader2Icon className="animate-spin" />}
           Regístrate
         </Button>

--- a/src/components/registration/teams/CreateTeamForm.tsx
+++ b/src/components/registration/teams/CreateTeamForm.tsx
@@ -161,7 +161,7 @@ export function CreateTeamForm({ formFields, profile, event }: CreateTeamFormPro
           )}
         />
 
-        <Button className="w-full bg-blue-500 dark:text-white" type="submit">
+        <Button className="w-full bg-blue-500 dark:text-white" type="submit" disabled={loading}>
           {loading && <Loader2Icon className="animate-spin" />}
           Crear Equipo y Registrame
         </Button>

--- a/src/lib/validators/formFields.ts
+++ b/src/lib/validators/formFields.ts
@@ -40,7 +40,7 @@ export function buildZodSchemaFromFields(fields: FormFieldSchema[]) {
         break
 
       case "file":
-        base = z.file()
+        base = z.file().max(5_000_000, "El archivo debe pesar menos de 5MB")
         break
 
       default:

--- a/src/pages/registro/[eventSlug].astro
+++ b/src/pages/registro/[eventSlug].astro
@@ -23,10 +23,11 @@ const registration = data?.claims
 if (!registration && event.registration_open === false)
   return Astro.redirect(`/registro/${eventSlug}/cerrado`)
 
-const team = await getTeamByRegistration(supabase, registration.id)
-
-if (team?.leader) {
-  return Astro.redirect(`/registro/${eventSlug}/invitar-miembros`)
+if (registration) {
+  const team = await getTeamByRegistration(supabase, registration.id)
+  if (team?.leader) {
+    return Astro.redirect(`/registro/${eventSlug}/invitar-miembros`)
+  }
 }
 
 if (registration?.status === "pending") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Se corrigió la lógica que valida la presencia de datos antes de acceder a información del equipo durante el registro.
* **Improvements**
  * Los botones de envío se deshabilitan mientras se está procesando para evitar envíos duplicados; siguen mostrando el indicador de carga.
  * Se añadió un límite de tamaño de archivo (5 MB) con mensaje de validación claro ("El archivo debe pesar menos de 5MB").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->