### PR TITLE
Feature/team crud

### DIFF
--- a/src/lib/services/teamService.ts
+++ b/src/lib/services/teamService.ts
@@ -163,13 +163,22 @@ export async function joinTeam(supabase: SupabaseClient, { code, event_id }: Joi
 
 export async function listMembers(
   supabase: SupabaseClient,
-  event_id: number
+  registration_id: number
 ): Promise<TeamMember[]> {
   const user = await getUser(supabase)
   if (!user) throw new Error("No se pudo obtener el usuario")
 
-  const userRegistration = await getRegistrationByUser(supabase, user.id, event_id)
-  if (!userRegistration) throw new Error("No se encontró el registro del usuario para este evento")
+  // Verificar que el registration_id pertenece al usuario autenticado
+  const { data: userRegistration, error: registrationError } = await supabase
+    .from("registrations")
+    .select("id")
+    .eq("id", registration_id)
+    .eq("user_id", user.id)
+    .maybeSingle()
+
+  if (registrationError)
+    throw new Error(`Error verificando inscripción: ${registrationError.message}`)
+  if (!userRegistration) throw new Error("Inscripción no encontrada o no te pertenece")
 
   const team = await getTeamByRegistration(supabase, userRegistration.id)
   if (!team) throw new Error("No pertenecés a ningún equipo")

--- a/src/lib/services/teamService.ts
+++ b/src/lib/services/teamService.ts
@@ -13,7 +13,7 @@ export interface TeamMember {
   user_id: string
   first_name: string
   last_name: string
-  email: string
+  email: string | null
 }
 
 interface CreateTeamParams {
@@ -161,20 +161,15 @@ export async function joinTeam(supabase: SupabaseClient, { code, event_id }: Joi
   return { success: true, team }
 }
 
-export async function listMembers(supabase: SupabaseClient): Promise<TeamMember[]> {
+export async function listMembers(
+  supabase: SupabaseClient,
+  event_id: number
+): Promise<TeamMember[]> {
   const user = await getUser(supabase)
   if (!user) throw new Error("No se pudo obtener el usuario")
 
-  // Obtener el registration del usuario autenticado
-  const { data: userRegistration, error: registrationError } = await supabase
-    .from("registrations")
-    .select("id")
-    .eq("user_id", user.id)
-    .single()
-
-  if (registrationError || !userRegistration) {
-    throw new Error("No se encontró el registro del usuario")
-  }
+  const userRegistration = await getRegistrationByUser(supabase, user.id, event_id)
+  if (!userRegistration) throw new Error("No se encontró el registro del usuario para este evento")
 
   const team = await getTeamByRegistration(supabase, userRegistration.id)
   if (!team) throw new Error("No pertenecés a ningún equipo")
@@ -213,20 +208,17 @@ export async function listMembers(supabase: SupabaseClient): Promise<TeamMember[
   )
 }
 
-export async function deleteMember(supabase: SupabaseClient, target_registration_id: number) {
+export async function deleteMember(
+  supabase: SupabaseClient,
+  target_registration_id: number,
+  event_id: number
+) {
   const user = await getUser(supabase)
   if (!user) throw new Error("No se pudo obtener el usuario")
 
-  // Obtener el registration del usuario autenticado (el líder)
-  const { data: leaderRegistration, error: leaderError } = await supabase
-    .from("registrations")
-    .select("id")
-    .eq("user_id", user.id)
-    .single()
-
-  if (leaderError || !leaderRegistration) {
-    throw new Error("No se encontró el registro del usuario")
-  }
+  const leaderRegistration = await getRegistrationByUser(supabase, user.id, event_id)
+  if (!leaderRegistration)
+    throw new Error("No se encontró el registro del usuario para este evento")
 
   // Obtener el equipo a partir del registration del líder
   const team = await getTeamByRegistration(supabase, leaderRegistration.id)
@@ -237,6 +229,17 @@ export async function deleteMember(supabase: SupabaseClient, target_registration
   if (leaderRegistration.id === target_registration_id) {
     throw new Error("No se puede eliminar al líder del equipo")
   }
+
+  // Verificar que el target pertenece al mismo equipo
+  const { data: targetMembership, error: membershipError } = await supabase
+    .from("team_registrations")
+    .select("registration_id")
+    .eq("team_id", team.id)
+    .eq("registration_id", target_registration_id)
+    .maybeSingle()
+
+  if (membershipError) throw new Error(`Error verificando membresía: ${membershipError.message}`)
+  if (!targetMembership) throw new Error("El miembro no pertenece a tu equipo")
 
   // Eliminar registration → CASCADE elimina team_registrations automáticamente
   const { error } = await supabase.from("registrations").delete().eq("id", target_registration_id)

--- a/src/lib/services/teamService.ts
+++ b/src/lib/services/teamService.ts
@@ -7,6 +7,15 @@ const nanoid = customAlphabet("ABCDEFGHJKLMNPQRSTUVWXYZ23456789", 6)
 
 export const MAX_TEAM_MEMBERS = 5
 
+export interface TeamMember {
+  registration_id: number
+  leader: boolean
+  user_id: string
+  first_name: string
+  last_name: string
+  email: string
+}
+
 interface CreateTeamParams {
   event_id: number
   name: string
@@ -150,4 +159,89 @@ export async function joinTeam(supabase: SupabaseClient, { code, event_id }: Joi
   }
 
   return { success: true, team }
+}
+
+export async function listMembers(supabase: SupabaseClient): Promise<TeamMember[]> {
+  const user = await getUser(supabase)
+  if (!user) throw new Error("No se pudo obtener el usuario")
+
+  // Obtener el registration del usuario autenticado
+  const { data: userRegistration, error: registrationError } = await supabase
+    .from("registrations")
+    .select("id")
+    .eq("user_id", user.id)
+    .single()
+
+  if (registrationError || !userRegistration) {
+    throw new Error("No se encontró el registro del usuario")
+  }
+
+  const team = await getTeamByRegistration(supabase, userRegistration.id)
+  if (!team) throw new Error("No pertenecés a ningún equipo")
+
+  if (!team.leader) throw new Error("Solo el líder puede ver los miembros del equipo")
+
+  // Obtener todos los miembros con sus perfiles
+  const { data, error } = await supabase
+    .from("team_registrations")
+    .select(
+      `registration_id,
+      leader,
+      registrations!inner(
+        user_id,
+        profiles!inner(
+          first_name,
+          last_name,
+          email
+        )
+      )`
+    )
+    .eq("team_id", team.id)
+    .order("leader", { ascending: false })
+
+  if (error) throw new Error(`Error obteniendo miembros: ${error.message}`)
+
+  return (
+    data?.map(member => ({
+      registration_id: member.registration_id,
+      leader: member.leader,
+      user_id: member.registrations.user_id,
+      first_name: member.registrations.profiles.first_name,
+      last_name: member.registrations.profiles.last_name,
+      email: member.registrations.profiles.email,
+    })) ?? []
+  )
+}
+
+export async function deleteMember(supabase: SupabaseClient, target_registration_id: number) {
+  const user = await getUser(supabase)
+  if (!user) throw new Error("No se pudo obtener el usuario")
+
+  // Obtener el registration del usuario autenticado (el líder)
+  const { data: leaderRegistration, error: leaderError } = await supabase
+    .from("registrations")
+    .select("id")
+    .eq("user_id", user.id)
+    .single()
+
+  if (leaderError || !leaderRegistration) {
+    throw new Error("No se encontró el registro del usuario")
+  }
+
+  // Obtener el equipo a partir del registration del líder
+  const team = await getTeamByRegistration(supabase, leaderRegistration.id)
+  if (!team) throw new Error("No pertenecés a ningún equipo")
+
+  if (!team.leader) throw new Error("Solo el líder puede eliminar miembros del equipo")
+
+  if (leaderRegistration.id === target_registration_id) {
+    throw new Error("No se puede eliminar al líder del equipo")
+  }
+
+  // Eliminar registration → CASCADE elimina team_registrations automáticamente
+  const { error } = await supabase.from("registrations").delete().eq("id", target_registration_id)
+
+  if (error) throw new Error(`Error eliminando miembro: ${error.message}`)
+
+  return { success: true }
 }

--- a/src/lib/services/teamService.ts
+++ b/src/lib/services/teamService.ts
@@ -163,29 +163,36 @@ export async function joinTeam(supabase: SupabaseClient, { code, event_id }: Joi
 
 export async function listMembers(
   supabase: SupabaseClient,
+  team_id: number,
   registration_id: number
 ): Promise<TeamMember[]> {
   const user = await getUser(supabase)
   if (!user) throw new Error("No se pudo obtener el usuario")
 
+  // Verificar que el registration_id pertenece al usuario y es líder del team_id en una sola query
+  const { data: leaderCheck, error: leaderError } = await supabase
+    .from("team_registrations")
+    .select("registration_id")
+    .eq("team_id", team_id)
+    .eq("registration_id", registration_id)
+    .eq("leader", true)
+    .maybeSingle()
+
+  if (leaderError) throw new Error(`Error verificando liderazgo: ${leaderError.message}`)
+  if (!leaderCheck) throw new Error("No eres líder de este equipo")
+
   // Verificar que el registration_id pertenece al usuario autenticado
-  const { data: userRegistration, error: registrationError } = await supabase
+  const { data: registrationOwnership, error: ownershipError } = await supabase
     .from("registrations")
     .select("id")
     .eq("id", registration_id)
     .eq("user_id", user.id)
     .maybeSingle()
 
-  if (registrationError)
-    throw new Error(`Error verificando inscripción: ${registrationError.message}`)
-  if (!userRegistration) throw new Error("Inscripción no encontrada o no te pertenece")
+  if (ownershipError) throw new Error(`Error verificando propiedad: ${ownershipError.message}`)
+  if (!registrationOwnership) throw new Error("Esta inscripción no te pertenece")
 
-  const team = await getTeamByRegistration(supabase, userRegistration.id)
-  if (!team) throw new Error("No pertenecés a ningún equipo")
-
-  if (!team.leader) throw new Error("Solo el líder puede ver los miembros del equipo")
-
-  // Obtener todos los miembros con sus perfiles
+  // Obtener todos los miembros del equipo
   const { data, error } = await supabase
     .from("team_registrations")
     .select(
@@ -200,7 +207,7 @@ export async function listMembers(
         )
       )`
     )
-    .eq("team_id", team.id)
+    .eq("team_id", team_id)
     .order("leader", { ascending: false })
 
   if (error) throw new Error(`Error obteniendo miembros: ${error.message}`)
@@ -217,38 +224,41 @@ export async function listMembers(
   )
 }
 
-export async function deleteMember(
-  supabase: SupabaseClient,
-  target_registration_id: number,
-  event_id: number
-) {
+export async function deleteMember(supabase: SupabaseClient, target_registration_id: number) {
   const user = await getUser(supabase)
   if (!user) throw new Error("No se pudo obtener el usuario")
 
-  const leaderRegistration = await getRegistrationByUser(supabase, user.id, event_id)
-  if (!leaderRegistration)
-    throw new Error("No se encontró el registro del usuario para este evento")
-
-  // Obtener el equipo a partir del registration del líder
-  const team = await getTeamByRegistration(supabase, leaderRegistration.id)
-  if (!team) throw new Error("No pertenecés a ningún equipo")
-
-  if (!team.leader) throw new Error("Solo el líder puede eliminar miembros del equipo")
-
-  if (leaderRegistration.id === target_registration_id) {
-    throw new Error("No se puede eliminar al líder del equipo")
-  }
-
-  // Verificar que el target pertenece al mismo equipo
-  const { data: targetMembership, error: membershipError } = await supabase
+  // Encontrar el equipo del target y verificar que el usuario autenticado es líder del mismo equipo
+  const { data: teamInfo, error: teamError } = await supabase
     .from("team_registrations")
-    .select("registration_id")
-    .eq("team_id", team.id)
+    .select(`
+      team_id,
+      registration_id,
+      leader,
+      registrations!inner(user_id)
+    `)
     .eq("registration_id", target_registration_id)
     .maybeSingle()
 
-  if (membershipError) throw new Error(`Error verificando membresía: ${membershipError.message}`)
-  if (!targetMembership) throw new Error("El miembro no pertenece a tu equipo")
+  if (teamError) throw new Error(`Error obteniendo información del equipo: ${teamError.message}`)
+  if (!teamInfo) throw new Error("Registro no encontrado o no pertenece a ningún equipo")
+
+  // Verificar que el usuario autenticado es líder del mismo equipo
+  const { data: leaderCheck, error: leaderError } = await supabase
+    .from("team_registrations")
+    .select("registration_id, registrations!inner(user_id)")
+    .eq("team_id", teamInfo.team_id)
+    .eq("leader", true)
+    .maybeSingle()
+
+  if (leaderError) throw new Error(`Error verificando liderazgo: ${leaderError.message}`)
+  if (!leaderCheck || leaderCheck.registrations.user_id !== user.id) {
+    throw new Error("Solo el líder puede eliminar miembros del equipo")
+  }
+
+  if (leaderCheck.registration_id === target_registration_id) {
+    throw new Error("No se puede eliminar al líder del equipo")
+  }
 
   // Eliminar registration → CASCADE elimina team_registrations automáticamente
   const { error } = await supabase.from("registrations").delete().eq("id", target_registration_id)

--- a/src/pages/api/teams/deleteMember.ts
+++ b/src/pages/api/teams/deleteMember.ts
@@ -3,15 +3,19 @@ import type { APIRoute } from "astro"
 import { deleteMember } from "@/lib/services/teamService"
 import { createUserClient } from "@/lib/supabase"
 
-// DELETE /api/teams/deleteMember?registrationId=527&eventId=3
+const AUTH_ERRORS = [
+  "No se pudo obtener el usuario",
+  "Registro no encontrado o no pertenece a ningún equipo",
+  "Solo el líder puede eliminar miembros del equipo",
+  "No se puede eliminar al líder del equipo",
+]
+
+// DELETE /api/teams/deleteMember?registrationId=527
 export const DELETE: APIRoute = async ({ request, cookies }) => {
   const supabase = await createUserClient(cookies)
   const url = new URL(request.url)
   const rawRegistrationId = url.searchParams.get("registrationId")
-  const rawEventId = url.searchParams.get("eventId")
-
   const target_registration_id = Number(rawRegistrationId)
-  const event_id = Number(rawEventId)
 
   if (
     !rawRegistrationId ||
@@ -19,13 +23,13 @@ export const DELETE: APIRoute = async ({ request, cookies }) => {
     target_registration_id <= 0
   )
     return new Response("registrationId debe ser un entero positivo", { status: 400 })
-  if (!rawEventId || !Number.isInteger(event_id) || event_id <= 0)
-    return new Response("eventId debe ser un entero positivo", { status: 400 })
 
   try {
-    const result = await deleteMember(supabase, target_registration_id, event_id)
+    const result = await deleteMember(supabase, target_registration_id)
     return Response.json(result)
   } catch (error: any) {
-    return new Response(error.message, { status: 400 })
+    if (AUTH_ERRORS.includes(error.message)) return new Response(error.message, { status: 403 })
+
+    return new Response("Error interno del servidor", { status: 500 })
   }
 }

--- a/src/pages/api/teams/deleteMember.ts
+++ b/src/pages/api/teams/deleteMember.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro"
+
+import { deleteMember } from "@/lib/services/teamService"
+import { createUserClient } from "@/lib/supabase"
+
+// DELETE /api/teams/deleteMember?registrationId=527
+export const DELETE: APIRoute = async ({ request, cookies }) => {
+  const supabase = await createUserClient(cookies)
+  const url = new URL(request.url)
+  const target_registration_id = Number(url.searchParams.get("registrationId"))
+
+  if (!target_registration_id) {
+    return new Response("registrationId es requerido", { status: 400 })
+  }
+
+  try {
+    const result = await deleteMember(supabase, target_registration_id)
+    return Response.json(result)
+  } catch (error: any) {
+    return new Response(error.message, { status: 400 })
+  }
+}

--- a/src/pages/api/teams/deleteMember.ts
+++ b/src/pages/api/teams/deleteMember.ts
@@ -3,18 +3,27 @@ import type { APIRoute } from "astro"
 import { deleteMember } from "@/lib/services/teamService"
 import { createUserClient } from "@/lib/supabase"
 
-// DELETE /api/teams/deleteMember?registrationId=527
+// DELETE /api/teams/deleteMember?registrationId=527&eventId=3
 export const DELETE: APIRoute = async ({ request, cookies }) => {
   const supabase = await createUserClient(cookies)
   const url = new URL(request.url)
-  const target_registration_id = Number(url.searchParams.get("registrationId"))
+  const rawRegistrationId = url.searchParams.get("registrationId")
+  const rawEventId = url.searchParams.get("eventId")
 
-  if (!target_registration_id) {
-    return new Response("registrationId es requerido", { status: 400 })
-  }
+  const target_registration_id = Number(rawRegistrationId)
+  const event_id = Number(rawEventId)
+
+  if (
+    !rawRegistrationId ||
+    !Number.isInteger(target_registration_id) ||
+    target_registration_id <= 0
+  )
+    return new Response("registrationId debe ser un entero positivo", { status: 400 })
+  if (!rawEventId || !Number.isInteger(event_id) || event_id <= 0)
+    return new Response("eventId debe ser un entero positivo", { status: 400 })
 
   try {
-    const result = await deleteMember(supabase, target_registration_id)
+    const result = await deleteMember(supabase, target_registration_id, event_id)
     return Response.json(result)
   } catch (error: any) {
     return new Response(error.message, { status: 400 })

--- a/src/pages/api/teams/members.ts
+++ b/src/pages/api/teams/members.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro"
+
+import { listMembers } from "@/lib/services/teamService"
+import { createUserClient } from "@/lib/supabase"
+
+// GET /api/teams/members
+export const GET: APIRoute = async ({ cookies }) => {
+  const supabase = await createUserClient(cookies)
+
+  try {
+    const members = await listMembers(supabase)
+    return Response.json(members)
+  } catch (error: any) {
+    return new Response(error.message, { status: 400 })
+  }
+}

--- a/src/pages/api/teams/members.ts
+++ b/src/pages/api/teams/members.ts
@@ -5,23 +5,27 @@ import { createUserClient } from "@/lib/supabase"
 
 const AUTH_ERRORS = [
   "No se pudo obtener el usuario",
-  "Inscripción no encontrada o no te pertenece",
-  "No pertenecés a ningún equipo",
-  "Solo el líder puede ver los miembros del equipo",
+  "No eres líder de este equipo",
+  "Esta inscripción no te pertenece",
 ]
 
-// GET /api/teams/members?registrationId=123
+// GET /api/teams/members?teamId=1&registrationId=123
 export const GET: APIRoute = async ({ request, cookies }) => {
   const supabase = await createUserClient(cookies)
   const url = new URL(request.url)
+  const rawTeamId = url.searchParams.get("teamId")
   const rawRegistrationId = url.searchParams.get("registrationId")
+
+  const team_id = Number(rawTeamId)
   const registration_id = Number(rawRegistrationId)
 
+  if (!rawTeamId || !Number.isInteger(team_id) || team_id <= 0)
+    return new Response("teamId debe ser un entero positivo", { status: 400 })
   if (!rawRegistrationId || !Number.isInteger(registration_id) || registration_id <= 0)
     return new Response("registrationId debe ser un entero positivo", { status: 400 })
 
   try {
-    const members = await listMembers(supabase, registration_id)
+    const members = await listMembers(supabase, team_id, registration_id)
     return Response.json(members)
   } catch (error: any) {
     if (AUTH_ERRORS.includes(error.message)) return new Response(error.message, { status: 403 })

--- a/src/pages/api/teams/members.ts
+++ b/src/pages/api/teams/members.ts
@@ -3,18 +3,29 @@ import type { APIRoute } from "astro"
 import { listMembers } from "@/lib/services/teamService"
 import { createUserClient } from "@/lib/supabase"
 
-// GET /api/teams/members?eventId=3
+const AUTH_ERRORS = [
+  "No se pudo obtener el usuario",
+  "Inscripción no encontrada o no te pertenece",
+  "No pertenecés a ningún equipo",
+  "Solo el líder puede ver los miembros del equipo",
+]
+
+// GET /api/teams/members?registrationId=123
 export const GET: APIRoute = async ({ request, cookies }) => {
   const supabase = await createUserClient(cookies)
   const url = new URL(request.url)
-  const event_id = Number(url.searchParams.get("eventId"))
+  const rawRegistrationId = url.searchParams.get("registrationId")
+  const registration_id = Number(rawRegistrationId)
 
-  if (!event_id) return new Response("eventId es requerido", { status: 400 })
+  if (!rawRegistrationId || !Number.isInteger(registration_id) || registration_id <= 0)
+    return new Response("registrationId debe ser un entero positivo", { status: 400 })
 
   try {
-    const members = await listMembers(supabase, event_id)
+    const members = await listMembers(supabase, registration_id)
     return Response.json(members)
   } catch (error: any) {
-    return new Response(error.message, { status: 400 })
+    if (AUTH_ERRORS.includes(error.message)) return new Response(error.message, { status: 403 })
+
+    return new Response("Error interno del servidor", { status: 500 })
   }
 }

--- a/src/pages/api/teams/members.ts
+++ b/src/pages/api/teams/members.ts
@@ -3,12 +3,16 @@ import type { APIRoute } from "astro"
 import { listMembers } from "@/lib/services/teamService"
 import { createUserClient } from "@/lib/supabase"
 
-// GET /api/teams/members
-export const GET: APIRoute = async ({ cookies }) => {
+// GET /api/teams/members?eventId=3
+export const GET: APIRoute = async ({ request, cookies }) => {
   const supabase = await createUserClient(cookies)
+  const url = new URL(request.url)
+  const event_id = Number(url.searchParams.get("eventId"))
+
+  if (!event_id) return new Response("eventId es requerido", { status: 400 })
 
   try {
-    const members = await listMembers(supabase)
+    const members = await listMembers(supabase, event_id)
     return Response.json(members)
   } catch (error: any) {
     return new Response(error.message, { status: 400 })


### PR DESCRIPTION
@pablonoya se agregaron los endpoints los siguientes endpoints, las cuales unicamente los lideres de un equipo pueden usarlo.
// GET /api/teams/members?teamId=1&registrationId=123
- lista los miembros del team

// DELETE /api/teams/deleteMember?registrationId=527
- Elimina registration y su team_registration del miembro del equipo especificado en registrationId=527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la versión

* **New Features**
  * Gestión de miembros de equipo: nuevas operaciones para listar y eliminar miembros.
  * Endpoints API para obtener miembros y eliminar un miembro desde la interfaz.
  * Nuevo formato de datos para los miembros devuelto por la API.
  * Validaciones en las peticiones con mensajes claros en caso de error y control estricto de permisos: solo el líder puede listar/eliminar miembros y no puede eliminarse a sí mismo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->